### PR TITLE
Support groups of only cooleres or only heaters

### DIFF
--- a/custom_components/hvac_group/climate.py
+++ b/custom_components/hvac_group/climate.py
@@ -106,8 +106,8 @@ async def async_setup_entry(
         max_temp,
         precision=precision,
         target_temperature_step=target_temperature_step,
-        heaters=hvac_actuator_entity_ids[CONF_HEATERS],
-        coolers=hvac_actuator_entity_ids[CONF_COOLERS],
+        heaters=hvac_actuator_entity_ids.get(CONF_HEATERS, set()),
+        coolers=hvac_actuator_entity_ids.get(CONF_COOLERS, set()),
         toggle_coolers=toggle_coolers,
         toggle_heaters=toggle_heaters,
     )

--- a/custom_components/hvac_group/climate.py
+++ b/custom_components/hvac_group/climate.py
@@ -1120,13 +1120,8 @@ class HvacGroupClimateEntity(ClimateEntity, RestoreEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set hvac mode callback."""
-        if hvac_mode not in (
-            HVACMode.OFF,
-            HVACMode.HEAT,
-            HVACMode.COOL,
-            HVACMode.HEAT_COOL,
-        ):
-            LOGGER.warning("Unrecognized hvac mode: %s", hvac_mode)
+        if hvac_mode not in self._attr_hvac_modes:
+            LOGGER.warning("Unsupported hvac mode: %s", hvac_mode)
             return
 
         LOGGER.debug("Setting mode %s on HVAC group %s", hvac_mode, self.entity_id)

--- a/custom_components/hvac_group/climate.py
+++ b/custom_components/hvac_group/climate.py
@@ -524,8 +524,8 @@ class HvacGroupClimateEntity(ClimateEntity, RestoreEntity):
         self._target_temp_low = target_temp_low
         self._target_temp_high = target_temp_high
 
-        self._toggle_heaters_on_threshold = toggle_heaters
-        self._toggle_coolers_on_threshold = toggle_coolers
+        self._toggle_heaters_on_threshold = toggle_heaters if self._heaters else False
+        self._toggle_coolers_on_threshold = toggle_coolers if self._coolers else False
 
         self._hvac_running_lock = asyncio.Lock()
         self._changing_actuators_lock = asyncio.Lock()
@@ -939,7 +939,7 @@ class HvacGroupClimateEntity(ClimateEntity, RestoreEntity):
 
             too_cold = self._target_temp_low >= self._current_temperature
             too_hot = self._current_temperature >= self._target_temp_high
-            if too_hot:
+            if too_hot and self._coolers:
                 needs_cooling = True
                 if (
                     (not self._are_coolers_active or update_actuators)
@@ -962,7 +962,7 @@ class HvacGroupClimateEntity(ClimateEntity, RestoreEntity):
                 )
                 await self._async_turn_off_coolers(pure=True)
 
-            if too_cold:
+            if too_cold and self._heaters:
                 needs_heating = True
                 if (
                     (not self._are_heaters_active or update_actuators)
@@ -1140,6 +1140,9 @@ class HvacGroupClimateEntity(ClimateEntity, RestoreEntity):
 
     async def _async_turn_on_coolers(self, pure: bool = False) -> None:
         """Turn on coolers. If `pure` is `True`, it only affects coolers which are not also heaters."""
+        if not self._coolers:
+            return
+
         self._are_coolers_active = True
         targets: HvacGroupActuatorDict = (
             HvacGroupActuatorDict(
@@ -1161,6 +1164,9 @@ class HvacGroupClimateEntity(ClimateEntity, RestoreEntity):
 
     async def _async_turn_off_coolers(self, pure: bool = False) -> None:
         """Turn off coolers. If `pure` is `True`, it only affects coolers which are not also heaters."""
+        if not self._coolers:
+            return
+
         self._are_coolers_active = False
         targets: HvacGroupActuatorDict = (
             HvacGroupActuatorDict(
@@ -1182,6 +1188,9 @@ class HvacGroupClimateEntity(ClimateEntity, RestoreEntity):
 
     async def _async_turn_on_heaters(self, pure: bool = False) -> None:
         """Turn on heaters. If `pure` is `True`, it only affects heaters which are not also coolers."""
+        if not self._heaters:
+            return
+
         self._are_heaters_active = True
         targets: HvacGroupActuatorDict = (
             HvacGroupActuatorDict(
@@ -1203,6 +1212,9 @@ class HvacGroupClimateEntity(ClimateEntity, RestoreEntity):
 
     async def _async_turn_off_heaters(self, pure: bool = False) -> None:
         """Turn off heaters. If `pure` is `True`, it only affects heaters which are not also coolers."""
+        if not self._heaters:
+            return
+
         self._are_heaters_active = False
         targets: HvacGroupActuatorDict = (
             HvacGroupActuatorDict(

--- a/custom_components/hvac_group/config_flow.py
+++ b/custom_components/hvac_group/config_flow.py
@@ -30,11 +30,11 @@ from .const import (
 )
 
 OPTIONS_SCHEMA = {
-    vol.Optional(CONF_HEATERS): selector.EntitySelector(
+    vol.Optional(CONF_HEATERS, default=set()): selector.EntitySelector(
         selector.EntitySelectorConfig(domain=CLIMATE_DOMAIN, multiple=True),
     ),
     vol.Optional(CONF_TOGGLE_HEATERS): selector.BooleanSelector(),
-    vol.Optional(CONF_COOLERS): selector.EntitySelector(
+    vol.Optional(CONF_COOLERS, default=set()): selector.EntitySelector(
         selector.EntitySelectorConfig(domain=CLIMATE_DOMAIN, multiple=True),
     ),
     vol.Optional(CONF_TOGGLE_COOLERS): selector.BooleanSelector(),


### PR DESCRIPTION
Fix #42 

Allow the creation of groups with only heaters or only coolers, with single temperature setpoints or temperature ranges.