### PR TITLE
Set temperature step based on temperature scale

### DIFF
--- a/custom_components/hvac_group/climate.py
+++ b/custom_components/hvac_group/climate.py
@@ -25,7 +25,7 @@ from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_NAME,
     PRECISION_HALVES,
-    PRECISION_TENTHS,
+    PRECISION_WHOLE,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
     UnitOfTemperature,
@@ -74,12 +74,17 @@ async def async_setup_entry(
 
     sensor_entity_id = config_entry.options.get(CONF_CURRENT_TEMPERATURE_ENTITY_ID)
 
-    precision = config_entry.options.get(CONF_PRECISION, PRECISION_TENTHS)
-    target_temperature_step = config_entry.options.get(
-        CONF_TARGET_TEMP_STEP, PRECISION_HALVES
-    )
-
     temperature_unit = hass.config.units.temperature_unit
+
+    precision = config_entry.options.get(CONF_PRECISION)
+    target_temperature_step = config_entry.options.get(
+        CONF_TARGET_TEMP_STEP,
+        (
+            PRECISION_HALVES
+            if temperature_unit == UnitOfTemperature.CELSIUS
+            else PRECISION_WHOLE
+        ),
+    )
 
     min_temp = config_entry.options.get(
         CONF_MIN_TEMP,
@@ -181,7 +186,7 @@ class HvacGroupClimateEntity(ClimateEntity, RestoreEntity):
         self._attr_unique_id = unique_id
 
         self._temperature_sensor_entity_id = temperature_sensor_entity_id
-        self._temp_precision = precision or PRECISION_TENTHS
+        self._temp_precision = precision
         self._temp_target_temperature_step = target_temperature_step
         self._attr_temperature_unit = temperature_unit
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -11,8 +11,10 @@ from homeassistant.components.climate import (
     ATTR_MAX_TEMP,
     ATTR_TARGET_TEMP_LOW,
     ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_STEP,
     ATTR_TEMPERATURE,
     DOMAIN as CLIMATE_DOMAIN,
+    PRECISION_WHOLE,
     SERVICE_SET_TEMPERATURE,
     ClimateEntityFeature,
     HVACMode,
@@ -25,6 +27,7 @@ from homeassistant.const import (
     CONF_ENTITY_ID,
     CONF_NAME,
     CONF_PLATFORM,
+    UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -171,6 +174,8 @@ async def hvac_group_entry(
 async def test_bare_setup(hass: HomeAssistant) -> None:
     """Test an empty config entry setup."""
 
+    hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+
     entry = MockConfigEntry(
         title="HVAC group 1",
         domain=DOMAIN,
@@ -213,6 +218,12 @@ async def test_bare_setup(hass: HomeAssistant) -> None:
     )
 
     assert entity_id == "climate.test_hvac"
+    assert (
+        hass.states.get(entity_id).attributes.get(ATTR_TARGET_TEMP_STEP)
+        == PRECISION_WHOLE
+    )
+
+    hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
 
 
 @pytest.mark.parametrize(("setup_extras", "group_extras"), [({}, {})])


### PR DESCRIPTION
Fixes #69

Target temp increment settings should depend on temperature scale (Fahrenheit or Celsius). For Celsius, half degrees are OK. For Fahrenheit, whole degrees are OK.