### PR TITLE
Bug fixes for HVAC modes and HA crashes and switched over to ha.core.event

### DIFF
--- a/custom_components/hvac_group/__init__.py
+++ b/custom_components/hvac_group/__init__.py
@@ -13,7 +13,6 @@ from .const import DOMAIN
 
 PLATFORMS = [Platform.CLIMATE]
 
-
 # https://developers.home-assistant.io/docs/config_entries_index/#setting-up-an-entry
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up this integration using UI."""
@@ -25,12 +24,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     return True
 
-
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Handle removal of an entry."""
-
-    return True
-
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+    return unload_ok
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload config entry."""

--- a/custom_components/hvac_group/climate.py
+++ b/custom_components/hvac_group/climate.py
@@ -965,29 +965,31 @@ class HvacGroupClimateEntity(ClimateEntity, RestoreEntity):
                 self._min_temp,
                 self._max_temp,
             )
-
+            
     def _add_heater(self, heater_entity_id: str) -> None:
         """Add a heater actuator referenced by entity_id."""
         if heater_entity_id in self._heaters:
             return
-
+    
         heater = HvacGroupHeater(self.hass, heater_entity_id)
         self._heaters.update({heater_entity_id: heater})
-
+        # Always update HVAC modes, regardless of state
+        self._update_hvac_modes(HvacActuatorType.HEATER)
+        # Only update features if state is available
         if heater.state:
-            self._update_hvac_modes(HvacActuatorType.HEATER)
             self._update_supported_features(heater.state)
 
     def _add_cooler(self, cooler_entity_id: str) -> None:
-        """Add a heater actuator referenced by entity_id."""
+        """Add a cooler actuator referenced by entity_id."""
         if cooler_entity_id in self._coolers:
             return
-
+    
         cooler = HvacGroupCooler(self.hass, cooler_entity_id)
         self._coolers.update({cooler_entity_id: cooler})
-
+        # Always update HVAC modes, regardless of state
+        self._update_hvac_modes(HvacActuatorType.COOLER)
+        # Only update features if state is available
         if cooler.state:
-            self._update_hvac_modes(HvacActuatorType.COOLER)
             self._update_supported_features(cooler.state)
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:

--- a/custom_components/hvac_group/climate.py
+++ b/custom_components/hvac_group/climate.py
@@ -965,12 +965,12 @@ class HvacGroupClimateEntity(ClimateEntity, RestoreEntity):
                 self._min_temp,
                 self._max_temp,
             )
-            
+
     def _add_heater(self, heater_entity_id: str) -> None:
         """Add a heater actuator referenced by entity_id."""
         if heater_entity_id in self._heaters:
             return
-    
+
         heater = HvacGroupHeater(self.hass, heater_entity_id)
         self._heaters.update({heater_entity_id: heater})
         # Always update HVAC modes, regardless of state
@@ -983,7 +983,7 @@ class HvacGroupClimateEntity(ClimateEntity, RestoreEntity):
         """Add a cooler actuator referenced by entity_id."""
         if cooler_entity_id in self._coolers:
             return
-    
+
         cooler = HvacGroupCooler(self.hass, cooler_entity_id)
         self._coolers.update({cooler_entity_id: cooler})
         # Always update HVAC modes, regardless of state

--- a/custom_components/hvac_group/climate.py
+++ b/custom_components/hvac_group/climate.py
@@ -39,7 +39,7 @@ from homeassistant.helpers.event import (
 )
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers import start
-from homeassistant.helpers.typing import EventType
+from homeassistant.core import Event
 from homeassistant.util.unit_conversion import TemperatureConverter
 
 from .const import (
@@ -403,7 +403,7 @@ class HvacGroupClimateEntity(ClimateEntity, RestoreEntity):
 
         @callback
         async def async_actuator_state_changed_listener(
-            event: EventType[EventStateChangedData],
+            event: Event[EventStateChangedData],
         ) -> None:
             """Handle actuator updates, like min/max temp changes."""
 
@@ -482,7 +482,7 @@ class HvacGroupClimateEntity(ClimateEntity, RestoreEntity):
 
         @callback
         async def async_sensor_state_changed_listener(
-            event: EventType[EventStateChangedData],
+            event: Event[EventStateChangedData],
         ) -> None:
             """Handle temperature sensor updates."""
 


### PR DESCRIPTION
Fixed issues with HA crashing when changing config and missing HVAC modes on HA restart.
Switched over to ha.core.event

- https://github.com/tetele/hvac_group/issues/119
- https://github.com/tetele/hvac_group/issues/120